### PR TITLE
Changed JSONSerializer Signature

### DIFF
--- a/DoritoPatcherWPF/GameFileShare.cs
+++ b/DoritoPatcherWPF/GameFileShare.cs
@@ -80,7 +80,7 @@ namespace DoritoPatcherWPF
             string json = wc.DownloadString(string.Format("https://{0}/api/{1}/{2}", blamUri.Host, type, id));
             
             
-            return Utils.JSONSerializer<Model>.DeSerialize(json);
+            return Utils.JSONSerializer.DeSerialize<Model>(json);
         }
 
         /// <summary>

--- a/DoritoPatcherWPF/Utils/JSONSerializer.cs
+++ b/DoritoPatcherWPF/Utils/JSONSerializer.cs
@@ -7,12 +7,12 @@ using System.Text;
 
 namespace DoritoPatcherWPF.Utils
 {
-    public static class JSONSerializer<TType> where TType : class
+    public static class JSONSerializer
     {
         /// <summary>
         /// Serializes an object to JSON
         /// </summary>
-        public static string Serialize(TType instance)
+        public static string Serialize<TType>(TType instance)
         {
             var serializer = new DataContractJsonSerializer(typeof(TType));
             using (var stream = new MemoryStream())
@@ -25,11 +25,12 @@ namespace DoritoPatcherWPF.Utils
         /// <summary>
         /// DeSerializes an object from JSON
         /// </summary>
-        public static TType DeSerialize(string json)
+        public static TType DeSerialize<TType>(string json)
+            where TType : class
         {
             using (var stream = new MemoryStream(Encoding.Default.GetBytes(json)))
             {
-                var serializer = new DataContractJsonSerializer(typeof(TType));
+			    var serializer = new DataContractJsonSerializer(typeof(TType));
                 return serializer.ReadObject(stream) as TType;
             }
         }

--- a/DoritoPatcherWPF/Utils/JSONSerializer.cs
+++ b/DoritoPatcherWPF/Utils/JSONSerializer.cs
@@ -30,7 +30,7 @@ namespace DoritoPatcherWPF.Utils
         {
             using (var stream = new MemoryStream(Encoding.Default.GetBytes(json)))
             {
-			    var serializer = new DataContractJsonSerializer(typeof(TType));
+                var serializer = new DataContractJsonSerializer(typeof(TType));
                 return serializer.ReadObject(stream) as TType;
             }
         }


### PR DESCRIPTION
Changed JSONSerializer from a static generic class to a static class.
Instead, both methods are now generic but JSONSerializer.Serialize can now infer the type
parameter when called. This should be, in most cases, a benefit though Serialize is not yet used it seems.
